### PR TITLE
Fix README: correct clone URL, cd path, and Live Site URLFix README: …

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Quantum Crypto uses a simulated implementation of the **Kyber** algorithm, which
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/CODER7657/quantum_crypto.github.io.git
-   cd quantum_crypto.github.io
+   git clone https://github.com/CODER7657/quantum_crypto.git
+   cd quantum_crypto
    ```
 
 2. **Install dependencies**
@@ -56,7 +56,7 @@ Quantum Crypto uses a simulated implementation of the **Kyber** algorithm, which
    ```
 
 4. **Open in browser**
-   Navigate to `http://localhost:3000`
+   Navigate to http://localhost:3000
 
 ### Development Mode
 
@@ -74,14 +74,15 @@ npm run dev-frontend
 
 This repository is configured for automatic deployment to GitHub Pages:
 
-- **Trigger**: Pushing to the `main` branch automatically triggers deployment
-- **Workflow**: Uses `.github/workflows/jekyll-gh-pages.yml` for automated deployment
-- **Live Site**: Available at https://coder7657.github.io/quantum_crypto.github.io/
+- **Trigger**: Pushing to the main branch automatically triggers deployment
+- **Workflow**: Uses .github/workflows/jekyll-gh-pages.yml for automated deployment
+- **Live Site**: Available at [https://coder7657.github.io/quantum_crypto/](https://coder7657.github.io/quantum_crypto/)
 - **Build Process**: GitHub Actions builds and deploys the site using Jekyll
 
 ### Manual Deployment
 
 To manually trigger a deployment:
+
 1. Navigate to the Actions tab
 2. Select the "Jekyll" workflow
 3. Click "Run workflow" to manually trigger deployment
@@ -89,7 +90,7 @@ To manually trigger a deployment:
 ## 📁 Project Structure
 
 ```
-quantum_crypto.github.io/
+quantum_crypto/
 ├── .github/
 │   └── workflows/
 │       └── jekyll-gh-pages.yml  # GitHub Pages deployment workflow
@@ -113,11 +114,12 @@ quantum_crypto.github.io/
 
 ### Environment Variables
 
-- `PORT`: Server port (default: 3000)
+- **PORT**: Server port (default: 3000)
 
 ### Security Settings
 
 The application uses these cryptographic parameters:
+
 - **Key Exchange**: Kyber-1024 (simulated)
 - **Encryption**: AES-256-GCM
 - **Hashing**: SHA-256
@@ -142,6 +144,7 @@ This project is designed for educational purposes to demonstrate:
 ## 🔄 Fork Information & Custom Additions
 
 ### Original Repository
+
 This is a fork of [Ayush3422/quantum_crypto](https://github.com/Ayush3422/quantum_crypto)
 
 ### Custom Modifications by Pavan Patel
@@ -149,21 +152,25 @@ This is a fork of [Ayush3422/quantum_crypto](https://github.com/Ayush3422/quantu
 The following enhancements have been added to this fork:
 
 #### 📄 New Documentation
+
 - **QUANTUM_THREAT_ANALYSIS.md**: Comprehensive analysis of quantum computing threats to current cryptographic systems
 - **Enhanced README.md**: Improved documentation with GitHub Pages deployment instructions
 - **DEPLOYMENT.md**: Detailed deployment and setup instructions
 
 #### ⚙️ Workflow Enhancements
-- **GitHub Actions Integration**: Added `.github/workflows/jekyll-gh-pages.yml` for automated deployment
+
+- **GitHub Actions Integration**: Added .github/workflows/jekyll-gh-pages.yml for automated deployment
 - **Continuous Deployment**: Automated GitHub Pages deployment on main branch updates
 - **Build Optimization**: Streamlined build process for faster deployments
 
 #### 🔧 Technical Improvements
+
 - **Repository Structure**: Reorganized file structure for better maintainability
 - **Configuration Updates**: Enhanced package.json with additional scripts and metadata
 - **Error Handling**: Improved error handling in cryptographic operations
 
 #### 🌐 Deployment Features
+
 - **GitHub Pages Setup**: Complete GitHub Pages configuration
 - **Custom Domain Support**: Ready for custom domain configuration
 - **SSL/TLS**: Automatic HTTPS via GitHub Pages


### PR DESCRIPTION
…correct clone URL, cd path, and Live Site URLUpdate README.md

- Fix git clone URL from quantum_crypto.github.io.git to quantum_crypto.git
- Fix cd path from quantum_crypto.github.io to quantum_crypto
- Fix Live Site URL from quantum_crypto.github.io/ to quantum_crypto/
- Fix project structure path references